### PR TITLE
feat: implement numbers and esme_squalor leaf services

### DIFF
--- a/services/esme_squalor/Program.cs
+++ b/services/esme_squalor/Program.cs
@@ -3,6 +3,25 @@ builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
 
 var app = builder.Build();
 
-app.MapGet("/verdict", () => Results.Ok(new { verdict = "out" }));
+app.MapGet("/verdict", (int number) =>
+{
+    var dayScore = DayScore(DateTime.UtcNow.DayOfWeek);
+    var verdict = number > dayScore ? "in" : "out";
+    return Results.Ok(new { verdict });
+});
 
 app.Run();
+
+static int DayScore(DayOfWeek day) => day switch
+{
+    DayOfWeek.Monday    => 42,
+    DayOfWeek.Tuesday   => 46,
+    DayOfWeek.Wednesday => 32,
+    DayOfWeek.Thursday  => 49,
+    DayOfWeek.Friday    => 33,
+    DayOfWeek.Saturday  => 40,
+    DayOfWeek.Sunday    => 54,
+    _ => throw new ArgumentOutOfRangeException(nameof(day))
+};
+
+public partial class Program { }

--- a/services/esme_squalor/Tests/EsmeSqualor.Tests.csproj
+++ b/services/esme_squalor/Tests/EsmeSqualor.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/services/esme_squalor/Tests/UnitTest1.cs
+++ b/services/esme_squalor/Tests/UnitTest1.cs
@@ -1,10 +1,26 @@
-﻿namespace EsmeSqualor.Tests;
+using Microsoft.AspNetCore.Mvc.Testing;
 
-public class UnitTest1
+namespace EsmeSqualor.Tests;
+
+public class VerdictTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
 {
-    [Fact]
-    public void Test1()
-    {
+    private readonly HttpClient _client = factory.CreateClient();
 
+    [Fact]
+    public async Task Number_99_is_always_in()
+    {
+        var response = await _client.GetAsync("/verdict?number=99");
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"in\"", body);
+    }
+
+    [Fact]
+    public async Task Number_1_is_always_out()
+    {
+        var response = await _client.GetAsync("/verdict?number=1");
+        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"out\"", body);
     }
 }

--- a/services/numbers/Program.cs
+++ b/services/numbers/Program.cs
@@ -3,6 +3,10 @@ builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
 
 var app = builder.Build();
 
-app.MapGet("/number", () => Results.Ok(new { value = 0 }));
+app.MapGet("/number", () =>
+{
+    var value = Random.Shared.Next(1, 101);
+    return Results.Ok(new { value });
+});
 
 app.Run();

--- a/services/numbers/Tests/UnitTest1.cs
+++ b/services/numbers/Tests/UnitTest1.cs
@@ -1,10 +1,11 @@
-﻿namespace Numbers.Tests;
+namespace Numbers.Tests;
 
-public class UnitTest1
+public class NumbersTests
 {
     [Fact]
-    public void Test1()
+    public void Number_is_between_1_and_100()
     {
-
+        var value = Random.Shared.Next(1, 101);
+        Assert.InRange(value, 1, 100);
     }
 }


### PR DESCRIPTION
## Summary

- `numbers`: `GET /number` returns a random int 1–100 via `Random.Shared`
- `esme_squalor`: `GET /verdict?number=<n>` returns `"in"` if `number > day_score`, otherwise `"out"`
- Day scores: MON=42, TUE=46, WED=32, THU=49, FRI=33, SAT=40, SUN=54
- Tests via `WebApplicationFactory`: 99 is always "in", 1 is always "out"

## Note

`dotnet build layers.slnx` produces warnings (not errors) from a `Microsoft.AspNetCore.Mvc.Testing` + nested directory quirk in .NET 10. `dotnet test layers.slnx` runs cleanly — CI will use that directly.

## Test plan

- [ ] `dotnet test layers.slnx` — 4 tests pass (1 orchestrator placeholder, 1 numbers, 2 esme_squalor)
- [ ] `dotnet run --project services/numbers/Numbers.csproj` then `curl http://localhost:5001/number` — returns a number 1–100
- [ ] `curl "http://localhost:5002/verdict?number=99"` — returns `{"verdict":"in"}`
- [ ] `curl "http://localhost:5002/verdict?number=1"` — returns `{"verdict":"out"}`

Closes task 002.

🤖 Generated with [Claude Code](https://claude.com/claude-code)