### PR TITLE
feat: implement orchestrator BFF

### DIFF
--- a/services/orchestrator/Program.cs
+++ b/services/orchestrator/Program.cs
@@ -1,8 +1,44 @@
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddAWSLambdaHosting(LambdaEventSource.HttpApi);
 
+builder.Services.AddHttpClient("numbers", client =>
+{
+    client.BaseAddress = new Uri(builder.Configuration["Services__Numbers__BaseUrl"] ?? "http://localhost:5001");
+});
+
+builder.Services.AddHttpClient("esme_squalor", client =>
+{
+    client.BaseAddress = new Uri(builder.Configuration["Services__EsmeSqualor__BaseUrl"] ?? "http://localhost:5002");
+});
+
 var app = builder.Build();
 
-app.MapGet("/result", () => Results.Ok(new { total = 0 }));
+app.MapGet("/result", async (int count, IHttpClientFactory httpClientFactory) =>
+{
+    var numbers = httpClientFactory.CreateClient("numbers");
+    var esme = httpClientFactory.CreateClient("esme_squalor");
+
+    var numberTasks = Enumerable.Range(0, count)
+        .Select(_ => numbers.GetFromJsonAsync<NumberResponse>("/number"));
+
+    var numberResponses = await Task.WhenAll(numberTasks);
+
+    var verdictTasks = numberResponses
+        .Select(r => esme.GetFromJsonAsync<VerdictResponse>($"/verdict?number={r!.Value}"));
+
+    var verdicts = await Task.WhenAll(verdictTasks);
+
+    var total = numberResponses
+        .Zip(verdicts, (n, v) => (number: n!.Value, verdict: v!.Verdict))
+        .Where(x => x.verdict == "in")
+        .Sum(x => x.number);
+
+    return Results.Ok(new { total });
+});
 
 app.Run();
+
+record NumberResponse(int Value);
+record VerdictResponse(string Verdict);
+
+public partial class Program { }

--- a/services/orchestrator/Tests/Orchestrator.Tests.csproj
+++ b/services/orchestrator/Tests/Orchestrator.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/services/orchestrator/Tests/UnitTest1.cs
+++ b/services/orchestrator/Tests/UnitTest1.cs
@@ -1,10 +1,101 @@
-﻿namespace Orchestrator.Tests;
+using System.Net;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Http;
 
-public class UnitTest1
+namespace Orchestrator.Tests;
+
+public class OrchestratorTests
 {
-    [Fact]
-    public void Test1()
+    private static WebApplicationFactory<Program> BuildFactory(
+        Func<HttpRequestMessage, HttpResponseMessage> numbersHandler,
+        Func<HttpRequestMessage, HttpResponseMessage> esmeHandler)
     {
-
+        return new WebApplicationFactory<Program>().WithWebHostBuilder(host =>
+        {
+            host.ConfigureServices(services =>
+            {
+                services.ConfigureAll<HttpClientFactoryOptions>(options =>
+                {
+                    options.HttpMessageHandlerBuilderActions.Add(b =>
+                    {
+                        b.PrimaryHandler = b.Name switch
+                        {
+                            "numbers" => new StubHandler(numbersHandler),
+                            "esme_squalor" => new StubHandler(esmeHandler),
+                            _ => b.PrimaryHandler
+                        };
+                    });
+                });
+            });
+        });
     }
+
+    [Fact]
+    public async Task Returns_sum_of_in_numbers()
+    {
+        // numbers returns 50, esme says "in" → total = 50
+        var factory = BuildFactory(
+            _ => Json(new { value = 50 }),
+            _ => Json(new { verdict = "in" }));
+
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/result?count=1");
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(body);
+        Assert.Equal(50, doc.RootElement.GetProperty("total").GetInt32());
+    }
+
+    [Fact]
+    public async Task Returns_zero_when_all_out()
+    {
+        // numbers returns 10, esme says "out" → total = 0
+        var factory = BuildFactory(
+            _ => Json(new { value = 10 }),
+            _ => Json(new { verdict = "out" }));
+
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/result?count=3");
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(body);
+        Assert.Equal(0, doc.RootElement.GetProperty("total").GetInt32());
+    }
+
+    [Fact]
+    public async Task Calls_numbers_and_esme_count_times()
+    {
+        var numbersCalls = 0;
+        var esmeCalls = 0;
+
+        var factory = BuildFactory(
+            _ => { numbersCalls++; return Json(new { value = 99 }); },
+            _ => { esmeCalls++; return Json(new { verdict = "in" }); });
+
+        var client = factory.CreateClient();
+        await client.GetAsync("/result?count=3");
+
+        Assert.Equal(3, numbersCalls);
+        Assert.Equal(3, esmeCalls);
+    }
+
+    private static HttpResponseMessage Json(object body) =>
+        new(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                JsonSerializer.Serialize(body),
+                System.Text.Encoding.UTF8,
+                "application/json")
+        };
+}
+
+class StubHandler(Func<HttpRequestMessage, HttpResponseMessage> handler) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken) =>
+        Task.FromResult(handler(request));
 }


### PR DESCRIPTION
## Summary

- `GET /result?count=N` calls `numbers` N times in parallel, then calls `esme_squalor /verdict` for each result
- Sums the numbers whose verdict is `"in"`, returns `{ "total": <sum> }` (0 if none)
- Named `HttpClient` registrations via `IHttpClientFactory` — base URLs from configuration with localhost defaults

## Configuration

| Variable | Local default |
|---|---|
| `Services__Numbers__BaseUrl` | `http://localhost:5001` |
| `Services__EsmeSqualor__BaseUrl` | `http://localhost:5002` |

## Test plan

- [ ] `dotnet test layers.slnx` — 6 tests pass
- [ ] Start all three services (`dotnet run` in each directory) and `curl "http://localhost:5000/result?count=3"`

Closes task 003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)