### PR TITLE
fix: replace fake numbers test with real endpoint test

### DIFF
--- a/services/numbers/Numbers.csproj
+++ b/services/numbers/Numbers.csproj
@@ -14,4 +14,8 @@
     <Compile Remove="Tests/**" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="Numbers.Tests" />
+  </ItemGroup>
+
 </Project>

--- a/services/numbers/Tests/Numbers.Tests.csproj
+++ b/services/numbers/Tests/Numbers.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/services/numbers/Tests/UnitTest1.cs
+++ b/services/numbers/Tests/UnitTest1.cs
@@ -1,11 +1,22 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+
 namespace Numbers.Tests;
 
-public class NumbersTests
+public class NumbersTests(WebApplicationFactory<Program> factory) : IClassFixture<WebApplicationFactory<Program>>
 {
+    private readonly HttpClient _client = factory.CreateClient();
+
     [Fact]
-    public void Number_is_between_1_and_100()
+    public async Task Number_endpoint_returns_value_between_1_and_100()
     {
-        var value = Random.Shared.Next(1, 101);
+        var response = await _client.GetAsync("/number");
+        response.EnsureSuccessStatusCode();
+
+        var body = await response.Content.ReadAsStringAsync();
+        var doc = JsonDocument.Parse(body);
+        var value = doc.RootElement.GetProperty("value").GetInt32();
+
         Assert.InRange(value, 1, 100);
     }
 }


### PR DESCRIPTION
## Summary

The previous test called `Random.Shared.Next` directly — it tested .NET, not our code. Replaced with a `WebApplicationFactory`-based test that hits `GET /number` and asserts the response value is between 1 and 100.

Also adds `InternalsVisibleTo` to `Numbers.csproj` and `Microsoft.AspNetCore.Mvc.Testing` to the test project, consistent with the other two services.

## Test plan

- [ ] `dotnet test layers.slnx` — 6 tests pass

Closes task 009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)