### PR TITLE
feat: pale green background and capricious Esme

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -13,7 +13,7 @@
 
         body {
             font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-            background: #f5f5f5;
+            background: #e8f5e9;
             display: flex;
             justify-content: center;
             align-items: center;

--- a/services/esme_squalor/Program.cs
+++ b/services/esme_squalor/Program.cs
@@ -5,7 +5,8 @@ var app = builder.Build();
 
 app.MapGet("/verdict", (int number) =>
 {
-    var dayScore = DayScore(DateTime.UtcNow.DayOfWeek);
+    var mood = Random.Shared.Next(-15, 16);
+    var dayScore = DayScore(DateTime.UtcNow.DayOfWeek) + mood;
     var verdict = number > dayScore ? "in" : "out";
     return Results.Ok(new { verdict });
 });


### PR DESCRIPTION
## Summary

- Background colour changed from `#f5f5f5` (light grey) to `#e8f5e9` (pale green)
- Esme now applies a random ±15 mood modifier to her day score on each call — verdicts near the boundary become unpredictable

Existing boundary tests still hold: the highest possible threshold is 54+15=69 (always below 99) and the lowest is 32−15=17 (always above 1).

## Test plan

- [ ] `ci.yml` triggers on this PR and all tests pass
- [ ] On merge, `cd.yml` deploys updated Lambda and uploads new frontend to S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)